### PR TITLE
feat: support flat config

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-    extends: require.resolve('./eslint/node'),
-};

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,0 +1,3 @@
+const {flatConfigs} = require('./eslint');
+
+module.exports = flatConfigs.build('node');

--- a/eslint/flat/build.js
+++ b/eslint/flat/build.js
@@ -1,0 +1,61 @@
+const importPlugin = require('eslint-plugin-import');
+const js = require('@eslint/js');
+const stylistic = require('@stylistic/eslint-plugin');
+const comments = require('@eslint-community/eslint-plugin-eslint-comments/configs');
+const base = require('../internals/base');
+const importRules = require('../internals/import');
+const stylisticRules = require('../internals/stylistic').rules;
+const node = require('./presets/node');
+const browser = require('./presets/browser');
+const react = require('./presets/react');
+const typescript = require('./presets/typescript');
+
+const presetsMap = {
+    node,
+    browser,
+    react,
+    typescript,
+};
+
+/**
+ * @typedef {'node' | 'browser' | 'react' | 'typescript'} Preset
+ */
+
+/**
+ * Create eslint flat config
+ *
+ * @param {Array<Preset> | Preset} presets
+ * @param {{ tsconfigRootDir: string }} [config]
+ */
+module.exports = (presets, config) => [
+    js.configs.recommended,
+    base,
+    importPlugin.flatConfigs.recommended,
+    importRules,
+    comments.recommended,
+    {
+        languageOptions: {
+            ecmaVersion: 'latest',
+            sourceType: 'module',
+        },
+        linterOptions: {
+            reportUnusedDisableDirectives: true,
+        },
+        settings: {
+            'import/resolver': {node: {}},
+        },
+    },
+    {
+        plugins: {'@stylistic': stylistic},
+        rules: stylisticRules,
+    },
+    {
+        ignores: ['!.*.js'],
+    },
+    ...(Array.isArray(presets) ? presets : [presets]).flatMap(preset => {
+        if (preset === 'typescript') {
+            return presetsMap[preset]({tsconfigRootDir: config?.tsconfigRootDir});
+        }
+        return presetsMap[preset];
+    }),
+];

--- a/eslint/flat/presets/browser.js
+++ b/eslint/flat/presets/browser.js
@@ -1,0 +1,10 @@
+const globals = require('globals');
+
+module.exports = [
+    {
+        files: ['**/*.{js,mjs,mts,cjs,cts}'],
+        languageOptions: {
+            globals: globals.browser,
+        },
+    },
+];

--- a/eslint/flat/presets/node.js
+++ b/eslint/flat/presets/node.js
@@ -1,0 +1,10 @@
+const globals = require('globals');
+
+module.exports = [
+    {
+        files: ['**/*.{js,mjs,mts,cjs,cts}'],
+        languageOptions: {
+            globals: globals.node,
+        },
+    },
+];

--- a/eslint/flat/presets/react.js
+++ b/eslint/flat/presets/react.js
@@ -1,0 +1,30 @@
+const globals = require('globals');
+const reactPlugin = require('eslint-plugin-react');
+const reactHooks = require('eslint-plugin-react-hooks');
+const importPlugin = require('eslint-plugin-import');
+const reactRules = require('../../react').rules;
+
+module.exports = [
+    {
+        files: ['**/*.{js,mjs,cjs,jsx,mjsx,ts,tsx,mtsx}'],
+        settings: {
+            ...importPlugin.flatConfigs.react.settings,
+            react: {version: 'detect'},
+        },
+        languageOptions: {
+            ...reactPlugin.configs.flat.recommended.languageOptions,
+            ...importPlugin.flatConfigs.react.languageOptions,
+            globals: {
+                ...globals.browser,
+            },
+        },
+        plugins: {
+            ...reactPlugin.configs.flat.recommended.plugins,
+            'react-hooks': reactHooks,
+        },
+        rules: {
+            ...reactHooks.configs.recommended.rules,
+            ...reactRules,
+        },
+    },
+];

--- a/eslint/flat/presets/typescript.js
+++ b/eslint/flat/presets/typescript.js
@@ -1,0 +1,36 @@
+const importPlugin = require('eslint-plugin-import');
+const tseslint = require('typescript-eslint');
+const tsRules = require('../../typescript').overrides.at(0).rules;
+
+/**
+ * @param {{ tsconfigRootDir: string }} config
+ */
+module.exports = config => [
+    ...tseslint.configs.strictTypeChecked,
+    ...tseslint.configs.recommendedTypeChecked,
+    ...tseslint.configs.stylisticTypeChecked,
+    {
+        files: ['**/*.{ts,tsx,mtsx}'],
+        languageOptions: {
+            parser: tseslint.parser,
+            parserOptions: {
+                projectService: true,
+                tsconfigRootDir: config.tsconfigRootDir,
+            },
+        },
+        settings: {
+            ...importPlugin.flatConfigs.typescript.settings,
+        },
+        plugins: {
+            '@typescript-eslint': tseslint.plugin,
+        },
+        rules: {
+            ...importPlugin.flatConfigs.typescript.rules,
+            ...tsRules,
+        },
+    },
+    {
+        files: ['**/*.{js,mjs,cjs,jsx,mjsx}'],
+        ...tseslint.configs.disableTypeChecked,
+    },
+];

--- a/eslint/index.js
+++ b/eslint/index.js
@@ -1,0 +1,5 @@
+const build = require('./flat/build');
+
+module.exports.flatConfigs = {
+    build,
+};

--- a/eslint/internals/base.js
+++ b/eslint/internals/base.js
@@ -1,22 +1,6 @@
-/* eslint-disable max-lines */
-
 module.exports = {
     rules: {
-        indent: [
-            'error',
-            4,
-            {
-                ignoredNodes: ['TemplateLiteral'],
-                SwitchCase: 1,
-                flatTernaryExpressions: false,
-                offsetTernaryExpressions: false,
-                ignoreComments: false,
-            },
-        ],
         'no-redeclare': ['off'],
-        'template-curly-spacing': ['off', 'never'],
-        'brace-style': ['error', 'stroustrup'],
-        'function-call-argument-newline': ['warn', 'consistent'],
         'max-lines': [
             'warn',
             {
@@ -33,27 +17,15 @@ module.exports = {
                 skipComments: true,
             },
         ],
-        'no-multiple-empty-lines': [
-            'warn',
-            {
-                max: 1,
-                maxEOF: 0,
-                maxBOF: 0,
-            },
-        ],
         'no-duplicate-imports': ['off'],
-        'func-call-spacing': ['off', 'never'],
         'no-empty-function': [
             'off',
             {
                 allow: ['generatorFunctions', 'methods', 'generatorMethods', 'setters', 'asyncMethods'],
             },
         ],
-        'no-extra-parens': ['off', 'functions'],
         'no-unused-vars': ['off'],
         'init-declarations': ['off'],
-        semi: ['error', 'always'],
-        quotes: ['error', 'single'],
         'no-undef': ['off'],
         'require-await': ['off'],
         'no-use-before-define': [
@@ -80,45 +52,19 @@ module.exports = {
             },
         ],
         'accessor-pairs': ['error'],
-        'array-bracket-newline': ['warn', 'consistent'],
-        'array-bracket-spacing': ['error', 'never'],
         'array-callback-return': ['error'],
         'arrow-body-style': ['off'],
-        'arrow-parens': ['error', 'as-needed'],
-        'arrow-spacing': ['error'],
         'block-scoped-var': ['warn'],
-        'block-spacing': ['error', 'never'],
         'callback-return': ['off'],
         camelcase: ['error'],
         'capitalized-comments': ['off'],
         'class-methods-use-this': ['off'],
-        'comma-dangle': [
-            'error',
-            {
-                arrays: 'always-multiline',
-                objects: 'always-multiline',
-                imports: 'always-multiline',
-                exports: 'always-multiline',
-                functions: 'never',
-            },
-        ],
-        'comma-spacing': [
-            'error',
-            {
-                before: false,
-                after: true,
-            },
-        ],
-        'comma-style': ['error', 'last'],
         complexity: ['warn', 10],
-        'computed-property-spacing': ['error', 'never'],
         'consistent-return': ['off'],
         'consistent-this': ['off'],
         'constructor-super': ['error'],
         curly: ['error', 'all'],
         'default-case': ['off'],
-        'dot-location': ['error', 'property'],
-        'eol-last': ['error', 'always'],
         eqeqeq: [
             'error',
             'always',
@@ -130,13 +76,6 @@ module.exports = {
         'func-name-matching': ['off'],
         'func-names': ['warn', 'always'],
         'func-style': ['off'],
-        'generator-star-spacing': [
-            'error',
-            {
-                before: false,
-                after: true,
-            },
-        ],
         'global-require': ['warn'],
         'guard-for-in': ['warn'],
         'handle-callback-err': ['off'],
@@ -144,27 +83,7 @@ module.exports = {
         'id-length': ['off'],
         'id-match': ['off'],
         'indent-legacy': ['off'],
-        'jsx-quotes': ['error', 'prefer-double'],
-        'key-spacing': [
-            'error',
-            {
-                beforeColon: false,
-                afterColon: true,
-            },
-        ],
-        'keyword-spacing': ['error'],
-        'line-comment-position': ['off'],
-        'linebreak-style': ['error', 'unix'],
-        'lines-around-comment': ['off'],
         'max-depth': ['warn', 3],
-        'max-len': [
-            'error',
-            120,
-            4,
-            {
-                ignoreUrls: true,
-            },
-        ],
         'max-nested-callbacks': ['off'],
         'max-params': ['off'],
         'max-statements': [
@@ -174,11 +93,7 @@ module.exports = {
                 ignoreTopLevelFunctions: true,
             },
         ],
-        'max-statements-per-line': ['error'],
-        'multiline-ternary': ['off'],
         'new-cap': ['error'],
-        'new-parens': ['warn'],
-        'newline-per-chained-call': ['off'],
         'no-alert': ['warn'],
         'no-array-constructor': ['off'],
         'no-await-in-loop': ['off'],
@@ -190,13 +105,6 @@ module.exports = {
         'no-class-assign': ['error'],
         'no-compare-neg-zero': ['error'],
         'no-cond-assign': ['error'],
-        'no-confusing-arrow': [
-            'error',
-            {
-                allowParens: true,
-                onlyOneSimpleParam: false,
-            },
-        ],
         'no-console': [
             'error',
             {
@@ -224,9 +132,7 @@ module.exports = {
         'no-extra-bind': ['warn'],
         'no-extra-boolean-cast': ['error'],
         'no-extra-label': ['error'],
-        'no-extra-semi': ['error'],
         'no-fallthrough': ['error'],
-        'no-floating-decimal': ['error'],
         'no-func-assign': ['warn'],
         'no-global-assign': ['error'],
         'no-implicit-coercion': ['off'],
@@ -244,19 +150,8 @@ module.exports = {
         'no-lonely-if': ['error'],
         'no-loop-func': ['warn'],
         'no-magic-numbers': ['off'],
-        'no-mixed-operators': ['off'],
         'no-mixed-requires': ['off'],
-        'no-mixed-spaces-and-tabs': ['error'],
         'no-multi-assign': ['warn'],
-        'no-multi-spaces': [
-            'error',
-            {
-                exceptions: {
-                    Property: false,
-                },
-                ignoreEOLComments: false,
-            },
-        ],
         'no-multi-str': ['warn'],
         'no-negated-condition': ['warn'],
         'no-negated-in-lhs': ['error'],
@@ -297,12 +192,10 @@ module.exports = {
         'no-shadow-restricted-names': ['off'],
         'no-sparse-arrays': ['error'],
         'no-sync': ['off'],
-        'no-tabs': ['warn'],
         'no-template-curly-in-string': ['off'],
         'no-ternary': ['off'],
         'no-this-before-super': ['error'],
         'no-throw-literal': ['warn'],
-        'no-trailing-spaces': ['error'],
         'no-undef-init': ['warn'],
         'no-undefined': ['off'],
         'no-underscore-dangle': ['warn'],
@@ -331,25 +224,10 @@ module.exports = {
         'no-useless-return': ['error'],
         'no-var': ['error'],
         'no-warning-comments': ['off'],
-        'no-whitespace-before-property': ['error'],
         'no-with': ['error'],
-        'nonblock-statement-body-position': ['off'],
-        'object-curly-newline': [
-            'error',
-            {
-                consistent: true,
-                multiline: true,
-            },
-        ],
-        'object-curly-spacing': ['error', 'never'],
-        'object-property-newline': ['off'],
         'object-shorthand': ['off', 'consistent-as-needed'],
         'one-var': ['error', 'never'],
-        'one-var-declaration-per-line': ['error'],
         'operator-assignment': ['off'],
-        'operator-linebreak': ['error', 'before'],
-        'padded-blocks': ['off'],
-        'padding-line-between-statements': ['off'],
         'prefer-arrow-callback': [
             'warn',
             {
@@ -365,58 +243,19 @@ module.exports = {
         'prefer-rest-params': ['error'],
         'prefer-spread': ['warn'],
         'prefer-template': ['off'],
-        'quote-props': ['off'],
         radix: ['error'],
         'require-jsdoc': ['off'],
         'require-yield': ['error'],
-        'rest-spread-spacing': ['error', 'never'],
-        'semi-spacing': ['error'],
-        'semi-style': ['error', 'last'],
         'sort-imports': ['off'],
         'sort-keys': ['off'],
         'sort-vars': ['off'],
-        'space-before-blocks': ['error', 'always'],
-        'space-before-function-paren': [
-            'error',
-            {
-                anonymous: 'always',
-                named: 'never',
-                asyncArrow: 'always',
-            },
-        ],
-        'space-in-parens': ['error', 'never'],
-        'space-infix-ops': ['error'],
-        'space-unary-ops': ['warn'],
-        'spaced-comment': [
-            'error',
-            'always',
-            {
-                exceptions: ['-', '+', '\'', '#'],
-                block: {
-                    balanced: true,
-                },
-            },
-        ],
         strict: ['off'],
-        'switch-colon-spacing': [
-            'error',
-            {
-                before: false,
-                after: true,
-            },
-        ],
         'symbol-description': ['warn'],
-        'template-tag-spacing': ['error', 'never'],
         'unicode-bom': ['warn'],
         'use-isnan': ['error'],
         'valid-jsdoc': ['off'],
         'valid-typeof': ['error'],
         'vars-on-top': ['off'],
-        'wrap-iife': ['error', 'any'],
-        'wrap-regex': ['off'],
-        'yield-star-spacing': ['off'],
         yoda: ['warn'],
     },
 };
-
-/* eslint-enable max-lines */

--- a/eslint/internals/common.js
+++ b/eslint/internals/common.js
@@ -7,9 +7,10 @@ module.exports = {
     extends: [
         'eslint:recommended',
         'plugin:import/recommended',
-        'plugin:eslint-comments/recommended',
+        'plugin:@eslint-community/eslint-comments/recommended',
         require.resolve('./import'),
         require.resolve('./base'),
+        require.resolve('./stylistic'),
     ],
     env: {
         [`es${ECMA_VERSION}`]: true,

--- a/eslint/internals/import.js
+++ b/eslint/internals/import.js
@@ -47,5 +47,10 @@ module.exports = {
         'import/max-dependencies': ['off'],
         'import/no-unassigned-import': ['off'],
         'import/no-named-default': ['error'],
+        // type import related
+        'import/consistent-type-specifier-style': [
+            'error',
+            'prefer-top-level',
+        ],
     },
 };

--- a/eslint/internals/stylistic.js
+++ b/eslint/internals/stylistic.js
@@ -1,0 +1,205 @@
+module.exports = {
+    plugins: ['@stylistic'],
+    rules: {
+        '@stylistic/indent': ['error', 4],
+        '@stylistic/func-call-spacing': ['error'],
+        '@stylistic/member-delimiter-style': [
+            'error',
+            {
+                multiline: {
+                    delimiter: 'semi',
+                    requireLast: true,
+                },
+                singleline: {
+                    delimiter: 'comma',
+                    requireLast: false,
+                },
+            },
+        ],
+        '@stylistic/no-extra-parens': ['off'],
+        '@stylistic/semi': ['error'],
+        '@stylistic/type-annotation-spacing': ['error'],
+        '@stylistic/quotes': ['error', 'single'],
+        '@stylistic/template-curly-spacing': ['off', 'never'],
+        '@stylistic/brace-style': ['error', 'stroustrup'],
+        '@stylistic/function-call-argument-newline': ['warn', 'consistent'],
+        '@stylistic/no-multiple-empty-lines': [
+            'warn',
+            {
+                max: 1,
+                maxEOF: 0,
+                maxBOF: 0,
+            },
+        ],
+        '@stylistic/array-bracket-newline': ['warn', 'consistent'],
+        '@stylistic/array-bracket-spacing': ['error', 'never'],
+        '@stylistic/arrow-parens': ['error', 'as-needed'],
+        '@stylistic/arrow-spacing': ['error'],
+        '@stylistic/block-spacing': ['error', 'never'],
+        '@stylistic/comma-dangle': [
+            'error',
+            {
+                arrays: 'always-multiline',
+                objects: 'always-multiline',
+                imports: 'always-multiline',
+                exports: 'always-multiline',
+                functions: 'never',
+            },
+        ],
+        '@stylistic/comma-spacing': [
+            'error',
+            {
+                before: false,
+                after: true,
+            },
+        ],
+        '@stylistic/comma-style': ['error', 'last'],
+        '@stylistic/computed-property-spacing': ['error', 'never'],
+        '@stylistic/dot-location': ['error', 'property'],
+        '@stylistic/eol-last': ['error', 'always'],
+        '@stylistic/generator-star-spacing': [
+            'error',
+            {
+                before: false,
+                after: true,
+            },
+        ],
+        '@stylistic/jsx-quotes': ['error', 'prefer-double'],
+        '@stylistic/key-spacing': [
+            'error',
+            {
+                beforeColon: false,
+                afterColon: true,
+            },
+        ],
+        '@stylistic/keyword-spacing': ['error'],
+        '@stylistic/line-comment-position': ['off'],
+        '@stylistic/linebreak-style': ['error', 'unix'],
+        '@stylistic/lines-around-comment': ['off'],
+        '@stylistic/max-len': [
+            'error',
+            120,
+            4,
+            {
+                ignoreUrls: true,
+            },
+        ],
+        '@stylistic/max-statements-per-line': ['error'],
+        '@stylistic/multiline-ternary': ['off'],
+        '@stylistic/new-parens': ['warn'],
+        '@stylistic/newline-per-chained-call': ['off'],
+        '@stylistic/no-confusing-arrow': [
+            'error',
+            {
+                allowParens: true,
+                onlyOneSimpleParam: false,
+            },
+        ],
+        '@stylistic/no-extra-semi': ['error'],
+        '@stylistic/no-floating-decimal': ['error'],
+        '@stylistic/no-mixed-operators': ['off'],
+        '@stylistic/no-mixed-spaces-and-tabs': ['error'],
+        '@stylistic/no-multi-spaces': [
+            'error',
+            {
+                exceptions: {
+                    Property: false,
+                },
+                ignoreEOLComments: false,
+            },
+        ],
+        '@stylistic/no-tabs': ['warn'],
+        '@stylistic/no-trailing-spaces': ['error'],
+        '@stylistic/no-whitespace-before-property': ['error'],
+        '@stylistic/nonblock-statement-body-position': ['off'],
+        '@stylistic/object-curly-newline': [
+            'error',
+            {
+                consistent: true,
+                multiline: true,
+            },
+        ],
+        '@stylistic/object-curly-spacing': ['error', 'never'],
+        '@stylistic/object-property-newline': ['off'],
+        '@stylistic/one-var-declaration-per-line': ['error'],
+        '@stylistic/operator-linebreak': ['error', 'before'],
+        '@stylistic/padded-blocks': ['off'],
+        '@stylistic/padding-line-between-statements': ['off'],
+        '@stylistic/quote-props': ['off'],
+        '@stylistic/rest-spread-spacing': ['error', 'never'],
+        '@stylistic/semi-spacing': ['error'],
+        '@stylistic/semi-style': ['error', 'last'],
+        '@stylistic/space-before-blocks': ['error', 'always'],
+        '@stylistic/space-before-function-paren': [
+            'error',
+            {
+                anonymous: 'always',
+                named: 'never',
+                asyncArrow: 'always',
+            },
+        ],
+        '@stylistic/space-in-parens': ['error', 'never'],
+        '@stylistic/space-infix-ops': ['error'],
+        '@stylistic/space-unary-ops': ['warn'],
+        '@stylistic/spaced-comment': [
+            'error',
+            'always',
+            {
+                exceptions: ['-', '+', '\'', '#'],
+                block: {
+                    balanced: true,
+                },
+            },
+        ],
+        '@stylistic/switch-colon-spacing': [
+            'error',
+            {
+                before: false,
+                after: true,
+            },
+        ],
+        '@stylistic/template-tag-spacing': ['error', 'never'],
+        '@stylistic/wrap-iife': ['error', 'any'],
+        '@stylistic/wrap-regex': ['off'],
+        '@stylistic/yield-star-spacing': ['off'],
+        '@stylistic/jsx-closing-bracket-location': ['error', 'line-aligned'],
+        '@stylistic/jsx-curly-spacing': ['error', 'never'],
+        '@stylistic/jsx-equals-spacing': ['error', 'never'],
+        '@stylistic/jsx-first-prop-new-line': ['error', 'multiline-multiprop'],
+        '@stylistic/jsx-indent-props': ['error', 4],
+        '@stylistic/jsx-indent': ['error', 4],
+        '@stylistic/jsx-max-props-per-line': [
+            'error',
+            {
+                when: 'multiline',
+            },
+        ],
+        '@stylistic/jsx-pascal-case': [
+            'error',
+            {
+                allowAllCaps: true,
+            },
+        ],
+        '@stylistic/jsx-sort-props': ['off'],
+        '@stylistic/jsx-tag-spacing': [
+            'error',
+            {
+                closingSlash: 'never',
+                beforeSelfClosing: 'always',
+                beforeClosing: 'never',
+                afterOpening: 'never',
+            },
+        ],
+        '@stylistic/jsx-wrap-multilines': [
+            'error',
+            {
+                declaration: 'parens-new-line',
+                assignment: 'parens-new-line',
+                return: 'parens-new-line',
+                arrow: 'parens-new-line',
+            },
+        ],
+        '@stylistic/jsx-closing-tag-location': ['error'],
+        '@stylistic/jsx-props-no-multi-spaces': ['error'],
+    },
+};

--- a/eslint/react.js
+++ b/eslint/react.js
@@ -15,16 +15,12 @@ module.exports = {
         'react/forbid-foreign-prop-types': ['warn'],
         'react/forbid-prop-types': ['off'],
         'react/jsx-boolean-value': ['error', 'never'],
-        'react/jsx-closing-bracket-location': ['error', 'line-aligned'],
-        'react/jsx-curly-spacing': ['error', 'never'],
-        'react/jsx-equals-spacing': ['error', 'never'],
         'react/jsx-filename-extension': [
             'error',
             {
                 extensions: ['.js', '.jsx', '.es', '.tsx'],
             },
         ],
-        'react/jsx-first-prop-new-line': ['error', 'multiline-multiprop'],
         'react/jsx-handler-names': [
             'off',
             {
@@ -32,15 +28,7 @@ module.exports = {
                 eventHandlerPropPrefix: 'on',
             },
         ],
-        'react/jsx-indent-props': ['error', 4],
-        'react/jsx-indent': ['error', 4],
         'react/jsx-key': ['error'],
-        'react/jsx-max-props-per-line': [
-            'error',
-            {
-                when: 'multiline',
-            },
-        ],
         'react/jsx-no-comment-textnodes': ['warn'],
         'react/jsx-no-duplicate-props': [
             'error',
@@ -51,34 +39,7 @@ module.exports = {
         'react/jsx-no-literals': ['off'],
         'react/jsx-no-target-blank': ['error'],
         'react/jsx-no-undef': ['error'],
-        'react/jsx-pascal-case': [
-            'error',
-            {
-                allowAllCaps: true,
-            },
-        ],
-        'react/jsx-sort-props': ['off'],
-        'react/jsx-tag-spacing': [
-            'error',
-            {
-                closingSlash: 'never',
-                beforeSelfClosing: 'always',
-                beforeClosing: 'never',
-                afterOpening: 'never',
-            },
-        ],
         'react/jsx-uses-vars': ['error'],
-        'react/jsx-wrap-multilines': [
-            'error',
-            {
-                declaration: 'parens-new-line',
-                assignment: 'parens-new-line',
-                return: 'parens-new-line',
-                arrow: 'parens-new-line',
-            },
-        ],
-        'react/jsx-closing-tag-location': ['error'],
-        'react/jsx-props-no-multi-spaces': ['error'],
         'react/no-array-index-key': ['error'],
         'react/no-children-prop': ['error'],
         'react/no-danger-with-children': ['error'],

--- a/eslint/typescript.js
+++ b/eslint/typescript.js
@@ -8,18 +8,13 @@ module.exports = {
                 'plugin:import/typescript',
             ],
             rules: {
-                indent: ['off'],
-                '@typescript-eslint/indent': ['error', 4],
                 '@typescript-eslint/consistent-type-imports': [
                     'error',
                     {
                         prefer: 'type-imports',
                     },
                 ],
-                '@typescript-eslint/method-signature-style': [
-                    'error',
-                    'property',
-                ],
+                '@typescript-eslint/method-signature-style': ['error', 'property'],
                 '@typescript-eslint/naming-convention': [
                     'error',
                     {
@@ -35,6 +30,7 @@ module.exports = {
                 '@typescript-eslint/prefer-nullish-coalescing': ['warn'],
                 '@typescript-eslint/prefer-optional-chain': ['warn'],
                 '@typescript-eslint/restrict-plus-operands': ['off'],
+                '@typescript-eslint/restrict-template-expressions': ['off'],
                 '@typescript-eslint/adjacent-overload-signatures': ['error'],
                 '@typescript-eslint/array-type': [
                     'error',
@@ -45,11 +41,10 @@ module.exports = {
                 ],
                 '@typescript-eslint/await-thenable': ['warn'],
                 '@typescript-eslint/ban-ts-comment': ['error'],
-                '@typescript-eslint/ban-types': ['error'],
-                '@typescript-eslint/consistent-type-definitions': [
-                    'error',
-                    'interface',
-                ],
+                '@typescript-eslint/no-empty-object-type': ['error'],
+                '@typescript-eslint/no-unsafe-function-type': ['error'],
+                '@typescript-eslint/no-wrapper-object-types': ['error'],
+                '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
                 '@typescript-eslint/explicit-function-return-type': ['off'],
                 '@typescript-eslint/explicit-member-accessibility': [
                     'error',
@@ -57,26 +52,11 @@ module.exports = {
                         accessibility: 'no-public',
                     },
                 ],
-                '@typescript-eslint/func-call-spacing': ['error'],
-                '@typescript-eslint/member-delimiter-style': [
-                    'error',
-                    {
-                        multiline: {
-                            delimiter: 'semi',
-                            requireLast: true,
-                        },
-                        singleline: {
-                            delimiter: 'comma',
-                            requireLast: false,
-                        },
-                    },
-                ],
                 '@typescript-eslint/member-ordering': ['warn'],
                 '@typescript-eslint/no-array-constructor': ['error'],
                 '@typescript-eslint/no-empty-function': ['off'],
                 '@typescript-eslint/no-empty-interface': ['warn'],
                 '@typescript-eslint/no-explicit-any': ['off'],
-                '@typescript-eslint/no-extra-parens': ['off'],
                 '@typescript-eslint/no-extraneous-class': ['error'],
                 '@typescript-eslint/no-floating-promises': [
                     'error',
@@ -132,20 +112,10 @@ module.exports = {
                         allowProtectedClassPropertyAccess: false,
                     },
                 ],
-                semi: ['off'],
-                '@typescript-eslint/semi': ['error'],
                 '@typescript-eslint/strict-boolean-expressions': ['off'],
                 '@typescript-eslint/triple-slash-reference': ['error'],
-                '@typescript-eslint/type-annotation-spacing': ['error'],
                 '@typescript-eslint/unbound-method': ['off'],
                 '@typescript-eslint/unified-signatures': ['warn'],
-                quotes: ['off'],
-                '@typescript-eslint/quotes': ['error', 'single'],
-                // type import related
-                'import/consistent-type-specifier-style': [
-                    'error',
-                    'prefer-top-level',
-                ],
             },
         },
     ],

--- a/package.json
+++ b/package.json
@@ -13,6 +13,15 @@
         "eslint",
         "typescript.json"
     ],
+    "exports": {
+        "./eslint": "./eslint/index.js",
+        "./eslint/browser": "./eslint/browser.js",
+        "./eslint/node": "./eslint/node.js",
+        "./eslint/react": "./eslint/react.js",
+        "./eslint/typescript": "./eslint/typescript.js",
+        "./package.json": "./package.json",
+        "./typescript.json": "./typescript.json"
+    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/ycycwx/config.git"
@@ -26,15 +35,17 @@
     "homepage": "https://github.com/ycycwx/config#readme",
     "dependencies": {
         "@babel/eslint-parser": "^7.25.7",
-        "@rushstack/eslint-patch": "^1.8.0",
-        "@typescript-eslint/eslint-plugin": "^7.11.0",
-        "@typescript-eslint/parser": "^7.11.0",
+        "@eslint-community/eslint-plugin-eslint-comments": "^4.4.0",
+        "@eslint/js": "^9.12.0",
+        "@rushstack/eslint-patch": "^1.10.4",
+        "@stylistic/eslint-plugin": "^2.9.0",
         "eslint-import-resolver-alias": "^1.1.2",
         "eslint-import-resolver-typescript": "^3.6.1",
-        "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-react": "^7.37.1",
-        "eslint-plugin-react-hooks": "^4.6.0"
+        "eslint-plugin-react-hooks": "^5.1.0-rc.0",
+        "globals": "^15.9.0",
+        "typescript-eslint": "^8.8.1"
     },
     "devDependencies": {
         "@babel/core": "7.25.7",
@@ -51,7 +62,7 @@
     "peerDependencies": {
         "eslint": "^8.16.0"
     },
-    "packageManager": "pnpm@9.12.0",
+    "packageManager": "pnpm@9.12.1",
     "publishConfig": {
         "access": "public"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,40 +11,46 @@ importers:
       '@babel/eslint-parser':
         specifier: ^7.25.7
         version: 7.25.7(@babel/core@7.25.7)(eslint@8.57.1)
+      '@eslint-community/eslint-plugin-eslint-comments':
+        specifier: ^4.4.0
+        version: 4.4.0(eslint@8.57.1)
+      '@eslint/js':
+        specifier: ^9.12.0
+        version: 9.12.0
       '@rushstack/eslint-patch':
-        specifier: ^1.8.0
+        specifier: ^1.10.4
         version: 1.10.4
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^7.11.0
-        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(typescript@5.6.2)
-      '@typescript-eslint/parser':
-        specifier: ^7.11.0
-        version: 7.18.0(eslint@8.57.1)(typescript@5.6.2)
+      '@stylistic/eslint-plugin':
+        specifier: ^2.9.0
+        version: 2.9.0(eslint@8.57.1)(typescript@5.6.2)
       eslint-import-resolver-alias:
         specifier: ^1.1.2
         version: 1.1.2(eslint-plugin-import@2.31.0)
       eslint-import-resolver-typescript:
         specifier: ^3.6.1
-        version: 3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.2))(eslint-plugin-import@2.31.0)(eslint@8.57.1)
-      eslint-plugin-eslint-comments:
-        specifier: ^3.2.0
-        version: 3.2.0(eslint@8.57.1)
+        version: 3.6.3(@typescript-eslint/parser@8.8.1(eslint@8.57.1)(typescript@5.6.2))(eslint-plugin-import@2.31.0)(eslint@8.57.1)
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+        version: 2.31.0(@typescript-eslint/parser@8.8.1(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       eslint-plugin-react:
         specifier: ^7.37.1
         version: 7.37.1(eslint@8.57.1)
       eslint-plugin-react-hooks:
-        specifier: ^4.6.0
-        version: 4.6.2(eslint@8.57.1)
+        specifier: ^5.1.0-rc.0
+        version: 5.1.0-rc-fb9a90fa48-20240614(eslint@8.57.1)
+      globals:
+        specifier: ^15.9.0
+        version: 15.10.0
+      typescript-eslint:
+        specifier: ^8.8.1
+        version: 8.8.1(eslint@8.57.1)(typescript@5.6.2)
     devDependencies:
       '@babel/core':
         specifier: 7.25.7
         version: 7.25.7
       '@commitlint/cli':
         specifier: 19.5.0
-        version: 19.5.0(@types/node@22.7.4)(typescript@5.6.2)
+        version: 19.5.0(@types/node@22.7.5)(typescript@5.6.2)
       '@commitlint/config-conventional':
         specifier: 19.5.0
         version: 19.5.0
@@ -227,6 +233,12 @@ packages:
     resolution: {integrity: sha512-DSHae2obMSMkAtTBSOulg5X7/z+rGLxcXQIkg3OmWvY6wifojge5uVMydfhUvs7yQj+V7jNmRZ2Xzl8GJyqRgg==}
     engines: {node: '>=v18'}
 
+  '@eslint-community/eslint-plugin-eslint-comments@4.4.0':
+    resolution: {integrity: sha512-yljsWl5Qv3IkIRmJ38h3NrHXFCm4EUl55M8doGTF6hvzvFF8kRpextgSrg2dwHev9lzBZyafCr9RelGIyQm6fw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
+
   '@eslint-community/eslint-utils@4.4.0':
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -244,6 +256,10 @@ packages:
   '@eslint/js@8.57.1':
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@eslint/js@9.12.0':
+    resolution: {integrity: sha512-eohesHH8WFRUprDNyEREgqP6beG6htMeUYeCpkEgBCieCMme5r9zFWjzAJp//9S+Kub4rqE+jXe9Cp1a7IYIIA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -326,8 +342,8 @@ packages:
     peerDependencies:
       '@octokit/core': '>=6'
 
-  '@octokit/plugin-throttling@9.3.1':
-    resolution: {integrity: sha512-Qd91H4liUBhwLB2h6jZ99bsxoQdhgPk6TdwnClPyTBSDAdviGPceViEgUwj+pcQDmB/rfAXAXK7MTochpHM3yQ==}
+  '@octokit/plugin-throttling@9.3.2':
+    resolution: {integrity: sha512-FqpvcTpIWFpMMwIeSoypoJXysSAQ3R+ALJhXXSG1HTP3YZOIeLmcNcimKaXxTcws+Sh6yoRl13SJ5r8sXc1Fhw==}
     engines: {node: '>= 18'}
     peerDependencies:
       '@octokit/core': ^6.0.0
@@ -420,14 +436,20 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@stylistic/eslint-plugin@2.9.0':
+    resolution: {integrity: sha512-OrDyFAYjBT61122MIY1a3SfEgy3YCMgt2vL4eoPmvTwDBwyQhAXurxNQznlRD/jESNfYWfID8Ej+31LljvF7Xg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: '>=8.40.0'
+
   '@types/conventional-commits-parser@5.0.0':
     resolution: {integrity: sha512-loB369iXNmAZglwWATL+WRe+CRMmmBPtpolYzIebFaX4YA3x+BEfLqhUAV9WanycKI3TG1IMr5bMJDajDKLlUQ==}
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
-  '@types/node@22.7.4':
-    resolution: {integrity: sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==}
+  '@types/node@22.7.5':
+    resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -435,63 +457,62 @@ packages:
   '@types/semver@7.5.8':
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
 
-  '@typescript-eslint/eslint-plugin@7.18.0':
-    resolution: {integrity: sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==}
-    engines: {node: ^18.18.0 || >=20.0.0}
+  '@typescript-eslint/eslint-plugin@8.8.1':
+    resolution: {integrity: sha512-xfvdgA8AP/vxHgtgU310+WBnLB4uJQ9XdyP17RebG26rLtDrQJV3ZYrcopX91GrHmMoH8bdSwMRh2a//TiJ1jQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^7.0.0
-      eslint: ^8.56.0
+      '@typescript-eslint/parser': ^8.0.0 || ^8.0.0-alpha.0
+      eslint: ^8.57.0 || ^9.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@typescript-eslint/parser@7.18.0':
-    resolution: {integrity: sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==}
-    engines: {node: ^18.18.0 || >=20.0.0}
+  '@typescript-eslint/parser@8.8.1':
+    resolution: {integrity: sha512-hQUVn2Lij2NAxVFEdvIGxT9gP1tq2yM83m+by3whWFsWC+1y8pxxxHUFE1UqDu2VsGi2i6RLcv4QvouM84U+ow==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.56.0
+      eslint: ^8.57.0 || ^9.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@typescript-eslint/scope-manager@7.18.0':
-    resolution: {integrity: sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==}
-    engines: {node: ^18.18.0 || >=20.0.0}
+  '@typescript-eslint/scope-manager@8.8.1':
+    resolution: {integrity: sha512-X4JdU+66Mazev/J0gfXlcC/dV6JI37h+93W9BRYXrSn0hrE64IoWgVkO9MSJgEzoWkxONgaQpICWg8vAN74wlA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/type-utils@7.18.0':
-    resolution: {integrity: sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==}
-    engines: {node: ^18.18.0 || >=20.0.0}
-    peerDependencies:
-      eslint: ^8.56.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@typescript-eslint/types@7.18.0':
-    resolution: {integrity: sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==}
-    engines: {node: ^18.18.0 || >=20.0.0}
-
-  '@typescript-eslint/typescript-estree@7.18.0':
-    resolution: {integrity: sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==}
-    engines: {node: ^18.18.0 || >=20.0.0}
+  '@typescript-eslint/type-utils@8.8.1':
+    resolution: {integrity: sha512-qSVnpcbLP8CALORf0za+vjLYj1Wp8HSoiI8zYU5tHxRVj30702Z1Yw4cLwfNKhTPWp5+P+k1pjmD5Zd1nhxiZA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@typescript-eslint/utils@7.18.0':
-    resolution: {integrity: sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==}
-    engines: {node: ^18.18.0 || >=20.0.0}
-    peerDependencies:
-      eslint: ^8.56.0
+  '@typescript-eslint/types@8.8.1':
+    resolution: {integrity: sha512-WCcTP4SDXzMd23N27u66zTKMuEevH4uzU8C9jf0RO4E04yVHgQgW+r+TeVTNnO1KIfrL8ebgVVYYMMO3+jC55Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/visitor-keys@7.18.0':
-    resolution: {integrity: sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==}
-    engines: {node: ^18.18.0 || >=20.0.0}
+  '@typescript-eslint/typescript-estree@8.8.1':
+    resolution: {integrity: sha512-A5d1R9p+X+1js4JogdNilDuuq+EHZdsH9MjTVxXOdVFfTJXunKJR/v+fNNyO4TnoOn5HqobzfRlc70NC6HTcdg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@typescript-eslint/utils@8.8.1':
+    resolution: {integrity: sha512-/QkNJDbV0bdL7H7d0/y0qBbV2HTtf0TIyjSDTvvmQEzeVx8jEImEbLuOA4EsvE8gIgqMitns0ifb5uQhMj8d9w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+
+  '@typescript-eslint/visitor-keys@8.8.1':
+    resolution: {integrity: sha512-0/TdC3aeRAsW7MDvYRwEc1Uwm0TIBfzjPFgg60UU2Haj5qsCs9cc3zNgY71edqE3LbWfF/WoZQd3lJoDXFQpag==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
@@ -572,10 +593,6 @@ packages:
     resolution: {integrity: sha512-itaWrbYbqpGXkGhZPGUulwnhVf5Hpy1xiCFsGqyIGglbBxmG5vSjxQen3/WGOjPpNEv1RtBLKxbmVXm8HpJStQ==}
     engines: {node: '>= 0.4'}
 
-  array-union@2.1.0:
-    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
-    engines: {node: '>=8'}
-
   array.prototype.findlast@1.2.5:
     resolution: {integrity: sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==}
     engines: {node: '>= 0.4'}
@@ -636,8 +653,8 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  caniuse-lite@1.0.30001666:
-    resolution: {integrity: sha512-gD14ICmoV5ZZM1OdzPWmpx+q4GyefaK06zi8hmfHV5xe4/2nOQX3+Dw5o+fSqOws2xVwL9j+anOPFwHzdEdV4g==}
+  caniuse-lite@1.0.30001667:
+    resolution: {integrity: sha512-7LTwJjcRkzKFmtqGsibMeuXmvFDfZq/nzIjnmgCGzKKRVzjD72selLDK1oPF/Oxzmt4fNcPvTDvGqSDG4tCALw==}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -849,8 +866,8 @@ packages:
   duplexer2@0.1.4:
     resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
 
-  electron-to-chromium@1.5.32:
-    resolution: {integrity: sha512-M+7ph0VGBQqqpTT2YrabjNKSQ2fEl9PVx6AK3N558gDH9NO8O6XN9SXXFWRo9u9PbEg/bWq+tjXQr+eXmxubCw==}
+  electron-to-chromium@1.5.33:
+    resolution: {integrity: sha512-+cYTcFB1QqD4j4LegwLfpCNxifb6dDFUAwk6RsLusCwIaZI6or2f+q8rs5tTB2YC53HhOlIbEaqHMAAC8IOIwA==}
 
   emoji-regex@10.4.0:
     resolution: {integrity: sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==}
@@ -970,12 +987,6 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
 
-  eslint-plugin-eslint-comments@3.2.0:
-    resolution: {integrity: sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==}
-    engines: {node: '>=6.5.0'}
-    peerDependencies:
-      eslint: '>=4.19.1'
-
   eslint-plugin-import@2.31.0:
     resolution: {integrity: sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==}
     engines: {node: '>=4'}
@@ -986,11 +997,11 @@ packages:
       '@typescript-eslint/parser':
         optional: true
 
-  eslint-plugin-react-hooks@4.6.2:
-    resolution: {integrity: sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==}
+  eslint-plugin-react-hooks@5.1.0-rc-fb9a90fa48-20240614:
+    resolution: {integrity: sha512-xsiRwaDNF5wWNC4ZHLut+x/YcAxksUd9Rizt7LaEn3bV8VyYRpXnRJQlLOfYaVy9esk4DFP4zPPnoNVjq5Gc0w==}
     engines: {node: '>=10'}
     peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
 
   eslint-plugin-react@7.37.1:
     resolution: {integrity: sha512-xwTnwDqzbDRA8uJ7BMxPs/EXRB3i8ZfnOIp8BsxEQkT0nHPp+WWceqGgo6rKb9ctNi8GJLDT4Go5HAWELa/WMg==}
@@ -1014,10 +1025,19 @@ packages:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  eslint-visitor-keys@4.1.0:
+    resolution: {integrity: sha512-Q7lok0mqMUSf5a/AdAZkA5a/gHcO6snwQClVNNvFKCAVlxXucdU8pKydU5ZVZjBx5xr37vGbFFWtLQYreLzrZg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   eslint@8.57.1:
     resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
+
+  espree@10.2.0:
+    resolution: {integrity: sha512-upbkBJbckcCNBDBDXEbuhjbP68n+scUd3k/U2EkyM9nw+I/jPiL4cLF/Al06CF96wRltFda16sxDFrxsI1v0/g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
@@ -1218,13 +1238,13 @@ packages:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
     engines: {node: '>=8'}
 
+  globals@15.10.0:
+    resolution: {integrity: sha512-tqFIbz83w4Y5TCbtgjZjApohbuh7K9BxGYFm7ifwDR240tvdb7P9x+/9VvUKlmkPoiknoJtanI8UOrqxS3a7lQ==}
+    engines: {node: '>=18'}
+
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
-
-  globby@11.1.0:
-    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
-    engines: {node: '>=10'}
 
   globby@14.0.2:
     resolution: {integrity: sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==}
@@ -1530,8 +1550,9 @@ packages:
     resolution: {integrity: sha512-3YZcUUR2Wt1WsapF+S/WiA2WmlW0cWAoPccMqne7AxEBhCdFeTPjfv/Axb8V2gyCgY3nRw+ksZ3xSUX+R47iAg==}
     engines: {node: ^18.17 || >=20.6.1}
 
-  iterator.prototype@1.1.2:
-    resolution: {integrity: sha512-DR33HMMr8EzwuRL8Y9D3u2BMj8+RqSE850jfGu59kS7tbmPLzGkZmVSfyCFSDxuZiEY6Rzt3T2NA/qU+NwVj1w==}
+  iterator.prototype@1.1.3:
+    resolution: {integrity: sha512-FW5iMbeQ6rBGm/oKgzq2aW4KvAGpxPzYES8N4g4xNXUKpL1mclMvOe+76AcLDTvD+Ze+sOpVhgdAQEKF4L9iGQ==}
+    engines: {node: '>= 0.4'}
 
   java-properties@1.0.2:
     resolution: {integrity: sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==}
@@ -2036,6 +2057,10 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
   pidtree@0.6.0:
     resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
     engines: {node: '>=0.10'}
@@ -2219,10 +2244,6 @@ packages:
 
   skin-tone@2.0.0:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
-    engines: {node: '>=8'}
-
-  slash@3.0.0:
-    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
   slash@5.1.0:
@@ -2446,6 +2467,15 @@ packages:
   typed-array-length@1.0.6:
     resolution: {integrity: sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==}
     engines: {node: '>= 0.4'}
+
+  typescript-eslint@8.8.1:
+    resolution: {integrity: sha512-R0dsXFt6t4SAFjUSKFjMh4pXDtq04SsFKCVGDP3ZOzNP7itF0jBcZYU4fMsZr4y7O7V7Nc751dDeESbe4PbQMQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   typescript@5.6.2:
     resolution: {integrity: sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==}
@@ -2717,11 +2747,11 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@commitlint/cli@19.5.0(@types/node@22.7.4)(typescript@5.6.2)':
+  '@commitlint/cli@19.5.0(@types/node@22.7.5)(typescript@5.6.2)':
     dependencies:
       '@commitlint/format': 19.5.0
       '@commitlint/lint': 19.5.0
-      '@commitlint/load': 19.5.0(@types/node@22.7.4)(typescript@5.6.2)
+      '@commitlint/load': 19.5.0(@types/node@22.7.5)(typescript@5.6.2)
       '@commitlint/read': 19.5.0
       '@commitlint/types': 19.5.0
       tinyexec: 0.3.0
@@ -2768,7 +2798,7 @@ snapshots:
       '@commitlint/rules': 19.5.0
       '@commitlint/types': 19.5.0
 
-  '@commitlint/load@19.5.0(@types/node@22.7.4)(typescript@5.6.2)':
+  '@commitlint/load@19.5.0(@types/node@22.7.5)(typescript@5.6.2)':
     dependencies:
       '@commitlint/config-validator': 19.5.0
       '@commitlint/execute-rule': 19.5.0
@@ -2776,7 +2806,7 @@ snapshots:
       '@commitlint/types': 19.5.0
       chalk: 5.3.0
       cosmiconfig: 9.0.0(typescript@5.6.2)
-      cosmiconfig-typescript-loader: 5.0.0(@types/node@22.7.4)(cosmiconfig@9.0.0(typescript@5.6.2))(typescript@5.6.2)
+      cosmiconfig-typescript-loader: 5.0.0(@types/node@22.7.5)(cosmiconfig@9.0.0(typescript@5.6.2))(typescript@5.6.2)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -2827,6 +2857,12 @@ snapshots:
       '@types/conventional-commits-parser': 5.0.0
       chalk: 5.3.0
 
+  '@eslint-community/eslint-plugin-eslint-comments@4.4.0(eslint@8.57.1)':
+    dependencies:
+      escape-string-regexp: 4.0.0
+      eslint: 8.57.1
+      ignore: 5.3.2
+
   '@eslint-community/eslint-utils@4.4.0(eslint@8.57.1)':
     dependencies:
       eslint: 8.57.1
@@ -2849,6 +2885,8 @@ snapshots:
       - supports-color
 
   '@eslint/js@8.57.1': {}
+
+  '@eslint/js@9.12.0': {}
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
@@ -2934,7 +2972,7 @@ snapshots:
       '@octokit/types': 13.6.1
       bottleneck: 2.19.5
 
-  '@octokit/plugin-throttling@9.3.1(@octokit/core@6.1.2)':
+  '@octokit/plugin-throttling@9.3.2(@octokit/core@6.1.2)':
     dependencies:
       '@octokit/core': 6.1.2
       '@octokit/types': 13.6.1
@@ -3018,7 +3056,7 @@ snapshots:
       '@octokit/core': 6.1.2
       '@octokit/plugin-paginate-rest': 11.3.5(@octokit/core@6.1.2)
       '@octokit/plugin-retry': 7.1.2(@octokit/core@6.1.2)
-      '@octokit/plugin-throttling': 9.3.1(@octokit/core@6.1.2)
+      '@octokit/plugin-throttling': 9.3.2(@octokit/core@6.1.2)
       '@semantic-release/error': 4.0.0
       aggregate-error: 5.0.0
       debug: 4.3.7
@@ -3074,13 +3112,25 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@stylistic/eslint-plugin@2.9.0(eslint@8.57.1)(typescript@5.6.2)':
+    dependencies:
+      '@typescript-eslint/utils': 8.8.1(eslint@8.57.1)(typescript@5.6.2)
+      eslint: 8.57.1
+      eslint-visitor-keys: 4.1.0
+      espree: 10.2.0
+      estraverse: 5.3.0
+      picomatch: 4.0.2
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@types/conventional-commits-parser@5.0.0':
     dependencies:
-      '@types/node': 22.7.4
+      '@types/node': 22.7.5
 
   '@types/json5@0.0.29': {}
 
-  '@types/node@22.7.4':
+  '@types/node@22.7.5':
     dependencies:
       undici-types: 6.19.8
 
@@ -3088,14 +3138,14 @@ snapshots:
 
   '@types/semver@7.5.8': {}
 
-  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(typescript@5.6.2)':
+  '@typescript-eslint/eslint-plugin@8.8.1(@typescript-eslint/parser@8.8.1(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(typescript@5.6.2)':
     dependencies:
       '@eslint-community/regexpp': 4.11.1
-      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.6.2)
-      '@typescript-eslint/scope-manager': 7.18.0
-      '@typescript-eslint/type-utils': 7.18.0(eslint@8.57.1)(typescript@5.6.2)
-      '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.6.2)
-      '@typescript-eslint/visitor-keys': 7.18.0
+      '@typescript-eslint/parser': 8.8.1(eslint@8.57.1)(typescript@5.6.2)
+      '@typescript-eslint/scope-manager': 8.8.1
+      '@typescript-eslint/type-utils': 8.8.1(eslint@8.57.1)(typescript@5.6.2)
+      '@typescript-eslint/utils': 8.8.1(eslint@8.57.1)(typescript@5.6.2)
+      '@typescript-eslint/visitor-keys': 8.8.1
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
@@ -3106,12 +3156,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.2)':
+  '@typescript-eslint/parser@8.8.1(eslint@8.57.1)(typescript@5.6.2)':
     dependencies:
-      '@typescript-eslint/scope-manager': 7.18.0
-      '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.6.2)
-      '@typescript-eslint/visitor-keys': 7.18.0
+      '@typescript-eslint/scope-manager': 8.8.1
+      '@typescript-eslint/types': 8.8.1
+      '@typescript-eslint/typescript-estree': 8.8.1(typescript@5.6.2)
+      '@typescript-eslint/visitor-keys': 8.8.1
       debug: 4.3.7
       eslint: 8.57.1
     optionalDependencies:
@@ -3119,31 +3169,31 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@7.18.0':
+  '@typescript-eslint/scope-manager@8.8.1':
     dependencies:
-      '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/visitor-keys': 7.18.0
+      '@typescript-eslint/types': 8.8.1
+      '@typescript-eslint/visitor-keys': 8.8.1
 
-  '@typescript-eslint/type-utils@7.18.0(eslint@8.57.1)(typescript@5.6.2)':
+  '@typescript-eslint/type-utils@8.8.1(eslint@8.57.1)(typescript@5.6.2)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.6.2)
-      '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.6.2)
+      '@typescript-eslint/typescript-estree': 8.8.1(typescript@5.6.2)
+      '@typescript-eslint/utils': 8.8.1(eslint@8.57.1)(typescript@5.6.2)
       debug: 4.3.7
-      eslint: 8.57.1
       ts-api-utils: 1.3.0(typescript@5.6.2)
     optionalDependencies:
       typescript: 5.6.2
     transitivePeerDependencies:
+      - eslint
       - supports-color
 
-  '@typescript-eslint/types@7.18.0': {}
+  '@typescript-eslint/types@8.8.1': {}
 
-  '@typescript-eslint/typescript-estree@7.18.0(typescript@5.6.2)':
+  '@typescript-eslint/typescript-estree@8.8.1(typescript@5.6.2)':
     dependencies:
-      '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/visitor-keys': 7.18.0
+      '@typescript-eslint/types': 8.8.1
+      '@typescript-eslint/visitor-keys': 8.8.1
       debug: 4.3.7
-      globby: 11.1.0
+      fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.3
@@ -3153,20 +3203,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@7.18.0(eslint@8.57.1)(typescript@5.6.2)':
+  '@typescript-eslint/utils@8.8.1(eslint@8.57.1)(typescript@5.6.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.1)
-      '@typescript-eslint/scope-manager': 7.18.0
-      '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.6.2)
+      '@typescript-eslint/scope-manager': 8.8.1
+      '@typescript-eslint/types': 8.8.1
+      '@typescript-eslint/typescript-estree': 8.8.1(typescript@5.6.2)
       eslint: 8.57.1
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/visitor-keys@7.18.0':
+  '@typescript-eslint/visitor-keys@8.8.1':
     dependencies:
-      '@typescript-eslint/types': 7.18.0
+      '@typescript-eslint/types': 8.8.1
       eslint-visitor-keys: 3.4.3
 
   '@ungap/structured-clone@1.2.0': {}
@@ -3252,8 +3302,6 @@ snapshots:
       get-intrinsic: 1.2.4
       is-string: 1.0.7
 
-  array-union@2.1.0: {}
-
   array.prototype.findlast@1.2.5:
     dependencies:
       call-bind: 1.0.7
@@ -3330,8 +3378,8 @@ snapshots:
 
   browserslist@4.24.0:
     dependencies:
-      caniuse-lite: 1.0.30001666
-      electron-to-chromium: 1.5.32
+      caniuse-lite: 1.0.30001667
+      electron-to-chromium: 1.5.33
       node-releases: 2.0.18
       update-browserslist-db: 1.1.1(browserslist@4.24.0)
 
@@ -3345,7 +3393,7 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  caniuse-lite@1.0.30001666: {}
+  caniuse-lite@1.0.30001667: {}
 
   chalk@2.4.2:
     dependencies:
@@ -3471,9 +3519,9 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  cosmiconfig-typescript-loader@5.0.0(@types/node@22.7.4)(cosmiconfig@9.0.0(typescript@5.6.2))(typescript@5.6.2):
+  cosmiconfig-typescript-loader@5.0.0(@types/node@22.7.5)(cosmiconfig@9.0.0(typescript@5.6.2))(typescript@5.6.2):
     dependencies:
-      '@types/node': 22.7.4
+      '@types/node': 22.7.5
       cosmiconfig: 9.0.0(typescript@5.6.2)
       jiti: 1.21.6
       typescript: 5.6.2
@@ -3561,7 +3609,7 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  electron-to-chromium@1.5.32: {}
+  electron-to-chromium@1.5.33: {}
 
   emoji-regex@10.4.0: {}
 
@@ -3656,7 +3704,7 @@ snapshots:
       has-proto: 1.0.3
       has-symbols: 1.0.3
       internal-slot: 1.0.7
-      iterator.prototype: 1.1.2
+      iterator.prototype: 1.1.3
       safe-array-concat: 1.1.2
 
   es-object-atoms@1.0.0:
@@ -3689,7 +3737,7 @@ snapshots:
 
   eslint-import-resolver-alias@1.1.2(eslint-plugin-import@2.31.0):
     dependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.8.1(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
 
   eslint-import-resolver-node@0.3.9:
     dependencies:
@@ -3699,43 +3747,37 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.2))(eslint-plugin-import@2.31.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.8.1(eslint@8.57.1)(typescript@5.6.2))(eslint-plugin-import@2.31.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 8.57.1
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.8.1(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.8.1(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.8.1(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.6.2)
+      '@typescript-eslint/parser': 8.8.1(eslint@8.57.1)(typescript@5.6.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.2))(eslint-plugin-import@2.31.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.8.1(eslint@8.57.1)(typescript@5.6.2))(eslint-plugin-import@2.31.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-eslint-comments@3.2.0(eslint@8.57.1):
-    dependencies:
-      escape-string-regexp: 1.0.5
-      eslint: 8.57.1
-      ignore: 5.3.2
-
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.8.1(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -3746,7 +3788,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.8.1(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -3758,13 +3800,13 @@ snapshots:
       string.prototype.trimend: 1.0.8
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.6.2)
+      '@typescript-eslint/parser': 8.8.1(eslint@8.57.1)(typescript@5.6.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-react-hooks@4.6.2(eslint@8.57.1):
+  eslint-plugin-react-hooks@5.1.0-rc-fb9a90fa48-20240614(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
 
@@ -3803,6 +3845,8 @@ snapshots:
   eslint-visitor-keys@2.1.0: {}
 
   eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.1.0: {}
 
   eslint@8.57.1:
     dependencies:
@@ -3846,6 +3890,12 @@ snapshots:
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
+
+  espree@10.2.0:
+    dependencies:
+      acorn: 8.12.1
+      acorn-jsx: 5.3.2(acorn@8.12.1)
+      eslint-visitor-keys: 4.1.0
 
   espree@9.6.1:
     dependencies:
@@ -4081,19 +4131,12 @@ snapshots:
     dependencies:
       type-fest: 0.20.2
 
+  globals@15.10.0: {}
+
   globalthis@1.0.4:
     dependencies:
       define-properties: 1.2.1
       gopd: 1.0.1
-
-  globby@11.1.0:
-    dependencies:
-      array-union: 2.1.0
-      dir-glob: 3.0.1
-      fast-glob: 3.3.2
-      ignore: 5.3.2
-      merge2: 1.4.1
-      slash: 3.0.0
 
   globby@14.0.2:
     dependencies:
@@ -4361,7 +4404,7 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.uniqby: 4.7.0
 
-  iterator.prototype@1.1.2:
+  iterator.prototype@1.1.3:
     dependencies:
       define-properties: 1.2.1
       get-intrinsic: 1.2.4
@@ -4765,6 +4808,8 @@ snapshots:
 
   picomatch@2.3.1: {}
 
+  picomatch@4.0.2: {}
+
   pidtree@0.6.0: {}
 
   pify@3.0.0: {}
@@ -4991,8 +5036,6 @@ snapshots:
   skin-tone@2.0.0:
     dependencies:
       unicode-emoji-modifier-base: 1.0.0
-
-  slash@3.0.0: {}
 
   slash@5.1.0: {}
 
@@ -5230,6 +5273,17 @@ snapshots:
       has-proto: 1.0.3
       is-typed-array: 1.1.13
       possible-typed-array-names: 1.0.0
+
+  typescript-eslint@8.8.1(eslint@8.57.1)(typescript@5.6.2):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.8.1(@typescript-eslint/parser@8.8.1(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(typescript@5.6.2)
+      '@typescript-eslint/parser': 8.8.1(eslint@8.57.1)(typescript@5.6.2)
+      '@typescript-eslint/utils': 8.8.1(eslint@8.57.1)(typescript@5.6.2)
+    optionalDependencies:
+      typescript: 5.6.2
+    transitivePeerDependencies:
+      - eslint
+      - supports-color
 
   typescript@5.6.2: {}
 


### PR DESCRIPTION
1. Support flat config.
2. Migrate or upgrade plugins: `eslint-comments`, `stylistic`, `typescript-eslint`.
3. Support `exports` keyword in `package.json`.
4. Keep compatible with legacy eslint config (*.rc).